### PR TITLE
add --[no-]probe-git cli arg

### DIFF
--- a/postqa/cli.py
+++ b/postqa/cli.py
@@ -26,6 +26,7 @@ def run_post_qa():
 
     metric_json, job_json = build_json_docs(args.qa_json_path,
                                             args.lsstsw_dirname,
+                                            args.probe_git,
                                             registered_metrics)
     if not args.test:
         if metric_json:
@@ -87,10 +88,25 @@ and uses the following environment variables:
         default=False,
         action='store_true',
         help='Print the shimmed JSON rather than uploading it')
+
+    feature_parser = parser.add_mutually_exclusive_group(required=False)
+    feature_parser.add_argument(
+        '--probe-git',
+        dest='probe_git',
+        action='store_true')
+    feature_parser.add_argument(
+        '--no-probe-git',
+        dest='probe_git',
+        action='store_false')
+    parser.set_defaults(probe_git=True)
     return parser.parse_args()
 
 
-def build_json_docs(qa_json_path, lsstsw_dirname, registered_metrics=[]):
+def build_json_docs(
+        qa_json_path,
+        lsstsw_dirname,
+        probe_git=True,
+        registered_metrics=[]):
     """Build a json message for SQUASH's /api/jobs endpoint from
     validate_drp-type JSON data.
     """
@@ -101,7 +117,9 @@ def build_json_docs(qa_json_path, lsstsw_dirname, registered_metrics=[]):
                                                        registered_metrics)
 
     # Add 'packages' sub-document
-    lsstsw_install = lsstsw.Lsstsw(lsstsw_dirname)
+    lsstsw_install = lsstsw.Lsstsw(
+            dirname=lsstsw_dirname,
+            probe_git=probe_git)
     job_json.update(lsstsw_install.json)
 
     # Add metadata from the CI environment

--- a/postqa/lsstsw.py
+++ b/postqa/lsstsw.py
@@ -22,10 +22,11 @@ class Lsstsw(object):
     dirname : `str`
         Path of an ``lsstsw`` directory.
     """
-    def __init__(self, dirname):
+    def __init__(self, dirname, probe_git=True):
         super(Lsstsw, self).__init__()
         self._dirname = dirname
         self._load_repos_yaml()
+        self._probe_git = probe_git
 
     @property
     def manifest_path(self):
@@ -63,7 +64,10 @@ class Lsstsw(object):
 
         # Insert git branch information
         for pkg_doc in job_json['packages']:
-            pkg_doc['git_branch'] = self.package_branch(pkg_doc['name'])
+            if self._probe_git:
+                pkg_doc['git_branch'] = self.package_branch(pkg_doc['name'])
+            else:
+                pkg_doc['git_branch'] = 'unknown'
 
         # Insert git repo URLs
         for pkg_doc in job_json['packages']:

--- a/tests/test_lsstsw.py
+++ b/tests/test_lsstsw.py
@@ -53,6 +53,29 @@ def test_packages_json_schema(mocker, lsstsw_dir):
     schema = load_squash_packages_schema()
     validate(job_json['packages'], schema)
 
+def test_packages_json_from_git(mocker, lsstsw_dir):
+    """Verify `git_branch` value(s) are coming from git."""
+    # mock git.Repo in postqa.lsstsw so that a repo's active branch is master
+    # and doesn't attempt to actually query the repo in the filesystem.
+    mocker.patch('postqa.lsstsw.git.Repo')
+    postqa.lsstsw.git.Repo.return_value.active_branch.name = 'apples'
+
+    lsstsw = Lsstsw(lsstsw_dir)
+    job_json = lsstsw.json
+
+    assert job_json['packages'][0]['git_branch'] == 'apples'
+
+def test_packages_json_no_git(mocker, lsstsw_dir):
+    """Verify `git_branch` value(s) are *not* coming from git."""
+    # mock git.Repo in postqa.lsstsw so that a repo's active branch is master
+    # and doesn't attempt to actually query the repo in the filesystem.
+    mocker.patch('postqa.lsstsw.git.Repo')
+    postqa.lsstsw.git.Repo.return_value.active_branch.name = 'apples'
+
+    lsstsw = Lsstsw(lsstsw_dir, False)
+    job_json = lsstsw.json
+
+    assert job_json['packages'][0]['git_branch'] == 'unknown'
 
 def test_uri_validation(mocker, lsstsw_dir):
     mocker.patch('postqa.lsstsw.git.Repo')


### PR DESCRIPTION
This flag enables/disables probing of lsstsw managed git repos to
determine the `git_branch`.  When disabled, `git_branch` will always be
`unknown`.  The default value is `True`.